### PR TITLE
Handle ignored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ module.exports = options => {
 
 		let result = report.results;
 
+		if (result.length === 0) {
+			cb(null, file);
+			return;
+		}
+
 		if (options.quiet) {
 			result = xo.getErrorResults(result);
 		}

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import test from 'ava';
 import vinylFile from 'vinyl-file';
 import pEvent from 'p-event';
@@ -30,6 +31,8 @@ test('default formatter', async t => {
 });
 
 test('fix option', async t => {
+	fs.writeFileSync('.eslintignore', '_ignored.js');
+
 	const stream = xo({
 		fix: true
 	});
@@ -44,4 +47,21 @@ test('fix option', async t => {
 		contents: Buffer.from('alert()')
 	}));
 	await finish;
+
+	fs.unlinkSync('.eslintignore');
+});
+
+test.serial('ignored files', async t => {
+	fs.writeFileSync('.eslintignore', '_fixture.js');
+
+	const stream = xo();
+	stream.on('data', file => {
+		t.falsy(file.eslint);
+		t.pass();
+	});
+	const finish = pEvent(stream, 'finish');
+	stream.end(vinylFile.readSync('_fixture.js'));
+	await finish;
+
+	fs.unlinkSync('.eslintignore');
 });


### PR DESCRIPTION
Naive implementation of what [`gulp-eslint` does](https://github.com/adametry/gulp-eslint/blob/master/index.js#L31-L45). We could also do what they do and add some warnings when files are ignored behind an option.

Fixes #18.